### PR TITLE
Bump minimum required Python to 3.7

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -5,9 +5,8 @@ platform:
   - linux-32
 
 engine:
-  - python=2.7
-  - python=3.4
-  - python=3.5
+  - python=3.7
+  - python=3.8
 
 install:
   - conda config --set always_yes yes --set changeps1 no

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ env:
   global:
     - secure: "iU+A6BAnvvV1nee28Net4MEHfiXeylkB0HOJ6SxjGEP10oLPviiJ7xvOl/JOhjK2/ef1X+iOZminUQHlMq2j8zY3kpThsOTqXPjvM4ytFsp8D52sC2iFq5UcSHwC4NHx6vtA4Gby/2VCr6K8qIvnDVczvvCC9pTl1yyCqa/ONSA="
   matrix:
-    - ARCH=x86_64 PYTHON_VERSION=3.5
-    - ARCH=x86_64 PYTHON_VERSION=2.7
-    - ARCH=x86_64 PYTHON_VERSION=3.4
-    # - ARCH=x86 PYTHON_VERSION=3.5
+    - ARCH=x86_64 PYTHON_VERSION=3.7
+    - ARCH=x86_64 PYTHON_VERSION=3.8
+
 install:
   - |
     if [ $TRAVIS_OS_NAME == osx ]; then ARCH=MacOSX-$ARCH; else ARCH=Linux-$ARCH; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
     ANACONDA_TOKEN:
       secure: aGxw9nEg+McADa71cxEuNwcuufgptKexXZJh0HM0Msh5QP1EFa7we5g8gJsbSGCo
   matrix:
-    - PYTHON_VERSION: "3.5"
-    - PYTHON_VERSION: "2.7"
+    - PYTHON_VERSION: "3.7"
+    - PYTHON_VERSION: "3.8"
 matrix:
     fast_finish: true
 

--- a/rayopt/__init__.py
+++ b/rayopt/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,7 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function, absolute_import, division
 
 from .material import *
 from .elements import *

--- a/rayopt/analysis.py
+++ b/rayopt/analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 import matplotlib as mpl
@@ -37,10 +34,10 @@ class CenteredFormatter(mpl.ticker.ScalarFormatter):
     def __call__(self, value, pos=None):
         if value == self.center:
             return ""
-        return super(CenteredFormatter, self).__call__(value, pos)
+        return super().__call__(value, pos)
 
 
-class Analysis(object):
+class Analysis:
     figwidth = 12.
     run = True
     update = True

--- a/rayopt/cachend.py
+++ b/rayopt/cachend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2014 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
@@ -27,7 +24,7 @@ from .utils import public
 
 
 @public
-class CacheND(object):
+class CacheND:
     def __init__(self, solver, guess=None, **kwargs):
         self.solver = solver
         self.interpolator = None

--- a/rayopt/codev.py
+++ b/rayopt/codev.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import xml.etree.ElementTree as et
 

--- a/rayopt/conjugates.py
+++ b/rayopt/conjugates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2014 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 
@@ -63,7 +60,7 @@ class Conjugate(NameMixin):
             yield "  %s" % _
 
     def dict(self):
-        dat = super(Conjugate, self).dict()
+        dat = super().dict()
         dat["pupil"] = self.pupil.dict()
         if self.projection != "rectilinear":
             dat["projection"] = self.projection
@@ -103,7 +100,7 @@ class FiniteConjugate(Conjugate):
     finite = True
 
     def __init__(self, radius=0., **kwargs):
-        super(FiniteConjugate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.radius = radius
 
     @property
@@ -111,15 +108,14 @@ class FiniteConjugate(Conjugate):
         return not self.radius
 
     def dict(self):
-        dat = super(FiniteConjugate, self).dict()
+        dat = super().dict()
         if self.radius:
             dat["radius"] = float(self.radius)
         return dat
 
     def text(self):
         yield "Radius: %.3g" % self.radius
-        for _ in super(FiniteConjugate, self).text():
-            yield _
+        yield from super().text()
 
     def update(self, radius, pupil_distance, pupil_radius):
         self.pupil.update(pupil_distance, pupil_radius)
@@ -127,7 +123,7 @@ class FiniteConjugate(Conjugate):
             self.radius = radius
 
     def rescale(self, scale):
-        super(FiniteConjugate, self).rescale(scale)
+        super().rescale(scale)
         self.radius *= scale
 
     @property
@@ -177,7 +173,7 @@ class InfiniteConjugate(Conjugate):
     finite = False
 
     def __init__(self, angle=0., angle_deg=None, **kwargs):
-        super(InfiniteConjugate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if angle_deg is not None:
             angle = np.deg2rad(angle_deg)
         self.angle = angle
@@ -187,7 +183,7 @@ class InfiniteConjugate(Conjugate):
         return not self.angle
 
     def dict(self):
-        dat = super(InfiniteConjugate, self).dict()
+        dat = super().dict()
         if self.angle:
             dat["angle"] = float(self.angle)
         return dat
@@ -199,8 +195,7 @@ class InfiniteConjugate(Conjugate):
 
     def text(self):
         yield "Semi-Angle: %.3g deg" % np.rad2deg(self.angle)
-        for _ in super(InfiniteConjugate, self).text():
-            yield _
+        yield from super().text()
 
     @property
     def slope(self):

--- a/rayopt/elements.py
+++ b/rayopt/elements.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 from scipy.optimize import newton
@@ -30,7 +27,7 @@ from .material import Material
 
 
 @public
-class TransformMixin(object):
+class TransformMixin:
     def __init__(self, distance=0., direction=(0, 0, 1.), angles=(0, 0, 0),
                  offset=None):
         self.update(distance, direction, angles)
@@ -117,7 +114,7 @@ class TransformMixin(object):
         if np.allclose(rdir, 0):
             rdir = 1., 0, 0
         rot = rotation_matrix(rang, rdir).T
-        angles = euler_from_matrix(rot, str("rxyz"))
+        angles = euler_from_matrix(rot, "rxyz")
         self.update(self.distance, self.direction, angles)
 
     def update(self, distance, direction, angles):
@@ -152,7 +149,7 @@ class TransformMixin(object):
         else:
             self.rot_axis = None
         if not self.normal:
-            r1 = euler_matrix(axes=str("rxyz"), *tuple(a))[:3, :3]
+            r1 = euler_matrix(axes="rxyz", *tuple(a))[:3, :3]
             r = np.dot(r, r1)
         self.rot_normal = r
 
@@ -183,7 +180,7 @@ class Element(NameMixin, TransformMixin):
     _default_type = "spheroid"
 
     def __init__(self, radius=np.inf, diameter=None, **kwargs):
-        super(Element, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if diameter is not None:
             radius = diameter/2
         self.radius = radius
@@ -278,7 +275,7 @@ class Element(NameMixin, TransformMixin):
 @public
 class Interface(Element):
     def __init__(self, material=None, **kwargs):
-        super(Interface, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if material:
             material = Material.make(material)
         self.material = material
@@ -292,7 +289,7 @@ class Interface(Element):
         return n, n0/n
 
     def dict(self):
-        dat = super(Interface, self).dict()
+        dat = super().dict()
         if self.material is not None:
             dat["material"] = str(self.material)
         return dat
@@ -301,7 +298,7 @@ class Interface(Element):
         return self.material.refractive_index(wavelength)
 
     def paraxial_matrix(self, n0, l):
-        n, m = super(Interface, self).paraxial_matrix(n0, l)
+        n, m = super().paraxial_matrix(n0, l)
         if self.material is not None:
             n = self.refractive_index(l)
         return n, m
@@ -334,7 +331,7 @@ class Interface(Element):
         return self.surface_sag(r)
 
     def intercept(self, y, u):
-        s = super(Interface, self).intercept(y, u)
+        s = super().intercept(y, u)
         for i in range(y.shape[0]):
             yi, ui = y[None, i], u[None, i]
 
@@ -373,7 +370,7 @@ class Interface(Element):
 
     def surface_cut(self, axis, points):
         if self.material is None:
-            return super(Interface, self).surface_cut(axis, points)
+            return super().surface_cut(axis, points)
         rad = self.radius
         xyz = np.zeros((points, 3))
         xyz[:, axis] = np.linspace(-rad, rad, points)
@@ -416,7 +413,7 @@ class Interface(Element):
 class Spheroid(Interface):
     def __init__(self, curvature=0., conic=0., aspherics=None, roc=None,
                  alternate_intersection=False, **kwargs):
-        super(Spheroid, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if roc is not None:
             curvature = 1./roc
         self.alternate_intersection = alternate_intersection
@@ -429,7 +426,7 @@ class Spheroid(Interface):
             assert self.radius**2 <= 1/((1 + self.conic)*self.curvature**2)
 
     def dict(self):
-        dat = super(Spheroid, self).dict()
+        dat = super().dict()
         if self.curvature:
             dat["curvature"] = float(self.curvature)
         if self.conic:
@@ -510,7 +507,7 @@ class Spheroid(Interface):
         # Applied Optics IP, vol. 8, Issue 5, p.975
         #
         # [y', u'] = M * [y, u]
-        n, md = super(Spheroid, self).paraxial_matrix(n0, l)
+        n, md = super().paraxial_matrix(n0, l)
         c = self.curvature
         if self.aspherics is not None:
             c = c + 2*self.aspherics[0]
@@ -544,13 +541,13 @@ class Spheroid(Interface):
         return n, m
 
     def reverse(self):
-        super(Spheroid, self).reverse()
+        super().reverse()
         self.curvature *= -1
         if self.aspherics is not None:
             self.aspherics = [-ai for ai in self.aspherics]
 
     def rescale(self, scale):
-        super(Spheroid, self).rescale(scale)
+        super().rescale(scale)
         self.curvature /= scale
         if self.aspherics is not None:
             self.aspherics = [ai/scale**(2*i + 1) for i, ai in

--- a/rayopt/formats.py
+++ b/rayopt/formats.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import json
 

--- a/rayopt/gaussian_trace.py
+++ b/rayopt/gaussian_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import itertools
 
@@ -32,13 +29,13 @@ class GaussianTrace(Trace):
     # qi[i] is valid after the ith element perpendicular to/along
     # the excidence direction (assumes aligned()
     def __init__(self, system):
-        super(GaussianTrace, self).__init__(system)
+        super().__init__(system)
         self.allocate()
         self.rays()
         self.propagate()
 
     def allocate(self):
-        super(GaussianTrace, self).allocate()
+        super().allocate()
         self.qi = np.empty((self.length, 2, 2), dtype=np.complex_)
         self.n = np.empty(self.length)
 
@@ -73,7 +70,7 @@ class GaussianTrace(Trace):
         self.qi[0] = qi
 
     def propagate(self, start=1, stop=None):
-        super(GaussianTrace, self).propagate()
+        super().propagate()
         init = start - 1
         qi, n = self.qi[init], self.n[init]
         for j, (qi, n) in enumerate(self.system.propagate_gaussian(

--- a/rayopt/geometric_trace.py
+++ b/rayopt/geometric_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import itertools
 
@@ -38,7 +35,7 @@ class GeometricTrace(Trace):
     all in i-surface normal coordinates relative to vertex
     """
     def allocate(self, nrays):
-        super(GeometricTrace, self).allocate()
+        super().allocate()
         self.nrays = nrays
         self.n = np.empty(self.length)
         self.y = np.empty((self.length, nrays, 3))
@@ -73,7 +70,7 @@ class GeometricTrace(Trace):
         self.t[0] = 0
 
     def propagate(self, start=1, stop=None, clip=False):
-        super(GeometricTrace, self).propagate()
+        super().propagate()
         init = start - 1
         y, u, n, l = self.y[init], self.u[init], self.n[init], self.l
         y, u = self.system[init].from_normal(y, u)
@@ -249,11 +246,10 @@ class GeometricTrace(Trace):
             c = np.concatenate(
                 (self.n[:, None], self.path[:, None], t[:, i, None],
                  self.y[:, i, :], self.u[:, i, :]), axis=1)
-            for _ in self.print_coeffs(
+            yield from self.print_coeffs(
                     c, "n/track z/rel path/"
                     "height x/height y/height z/angle x/angle y/angle z"
-                    .split("/"), sum=False):
-                yield _
+                    .split("/"), sum=False)
             yield ""
 
     def text(self):

--- a/rayopt/library.py
+++ b/rayopt/library.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import os
 import shutil
@@ -51,7 +48,7 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 @public
-class Library(object):
+class Library:
     _one = None
 
     @classmethod

--- a/rayopt/library_items.py
+++ b/rayopt/library_items.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import os
 import io
@@ -32,7 +29,7 @@ from sqlalchemy.orm import relationship
 from .utils import public
 
 
-class Tablename(object):
+class Tablename:
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
@@ -133,7 +130,7 @@ class Catalog(Base):
                 return v(fil, session)
 
     def load(self, fil):
-        data = io.open(fil, "rb").read()
+        data = open(fil, "rb").read()
         self.file = fil
         stat = os.stat(fil)
         self.date = stat.st_mtime

--- a/rayopt/material.py
+++ b/rayopt/material.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import warnings
 
@@ -54,7 +51,7 @@ lambda_C = fraunhofer["C"]
 
 
 
-class Thermal(object):
+class Thermal:
     def __init__(self, d, e, tref=20., lref=lambda_d):
         self.d = d
         self.e = e
@@ -119,7 +116,7 @@ class Material(NameMixin):
 
     def __str__(self):
         if self.catalog is not None:
-            return "%s/%s" % (self.catalog, self.name)
+            return f"{self.catalog}/{self.name}"
         else:
             return self.name
 
@@ -163,14 +160,14 @@ class Material(NameMixin):
 @public
 class ModelMaterial(Material):
     def __init__(self, n=1., **kwargs):
-        super(ModelMaterial, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.n = n
 
     def refractive_index(self, wavelength):
         return self.n
 
     def dict(self):
-        dat = super(ModelMaterial, self).dict()
+        dat = super().dict()
         dat["n"] = self.n
         return dat
 
@@ -179,7 +176,7 @@ class ModelMaterial(Material):
 class AbbeMaterial(Material):
     def __init__(self, n=1., v=np.inf, lambda_ref=lambda_d,
                  lambda_long=lambda_C, lambda_short=lambda_F, **kwargs):
-        super(AbbeMaterial, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.n = n
         self.v = v
         self.lambda_ref = lambda_ref
@@ -208,7 +205,7 @@ class AbbeMaterial(Material):
                 (1 - self.n)/self.v)
 
     def dict(self):
-        dat = super(AbbeMaterial, self).dict()
+        dat = super().dict()
         dat["n"] = self.n
         dat["v"] = self.v
         if self.lambda_ref != lambda_d:
@@ -223,9 +220,9 @@ class AbbeMaterial(Material):
 @public
 class CoefficientsMaterial(Material):
     def __init__(self, coefficients, typ="sellmeier", **kwargs):
-        super(CoefficientsMaterial, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not hasattr(self, "n_%s" % typ):
-            warnings.warn("unknown dispersion %s (%s)" % (typ, self.name))
+            warnings.warn(f"unknown dispersion {typ} ({self.name})")
         self.typ = typ
         self.coefficients = np.atleast_1d(coefficients)
 
@@ -325,7 +322,7 @@ class CoefficientsMaterial(Material):
                        c[3]*(w - c[4])/((w - c[4])**2 + c[5]))
 
     def dict(self):
-        dat = super(CoefficientsMaterial, self).dict()
+        dat = super().dict()
         dat["typ"] = self.typ
         dat["coefficients"] = list(self.coefficients)
         return dat
@@ -337,10 +334,10 @@ mirror = Material(name="mirror", catalog="basic", solid=False, mirror=True)
 air = CoefficientsMaterial(
     name="air", catalog="basic", typ="gas", solid=False,
     coefficients=[.05792105, .00167917, 238.0185, 57.362])
-basic = dict((m.name, m) for m in (vacuum, air, mirror))
+basic = {m.name: m for m in (vacuum, air, mirror)}
 
 
-class DefaultGlass(object):
+class DefaultGlass:
     def __getitem__(self, key):
         return self.get(key)
 

--- a/rayopt/name_mixin.py
+++ b/rayopt/name_mixin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2014 Robert Jordens <robert@joerdens.org>
@@ -16,13 +15,11 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 __all__ = ["NameMixin"]
 
 
-class NameMixin(object):
+class NameMixin:
     _types = {}
     _default_type = None
     _nickname = None
@@ -71,4 +68,4 @@ class NameMixin(object):
         self._nickname = name
 
     def __str__(self):
-        return "<%s/%s>" % (self.typeletter, self.nickname)
+        return f"<{self.typeletter}/{self.nickname}>"

--- a/rayopt/optimize.py
+++ b/rayopt/optimize.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 from fastcache import clru_cache
 import numpy as np
@@ -48,7 +45,7 @@ class Variable:
 class PathVariable(Variable):
     def __init__(self, system, path, *args, **kwargs):
         self.path = path
-        super(PathVariable, self).__init__(system, *args, **kwargs)
+        super().__init__(system, *args, **kwargs)
 
     def get(self):
         return self.system.get_path(self.path)
@@ -86,7 +83,7 @@ class Operand:
 
 class FuncOp(Operand):
     def __init__(self, system, func, *args, **kwargs):
-        super(FuncOp, self).__init__(system, *args, **kwargs)
+        super().__init__(system, *args, **kwargs)
         self.func = func
 
     def get(self):

--- a/rayopt/oslo.py
+++ b/rayopt/oslo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import os.path
 import io
@@ -49,7 +46,7 @@ def dir_read(file, session):
     # offset, length, name, efl, diameter, thickness
     dir = np.loadtxt(file, delimiter=",", skiprows=1,
                      dtype="i,i,i,S64,f,f,f", ndmin=1)
-    lens = io.open("%s.dat" % prefix, "r")
+    lens = open("%s.dat" % prefix)
     lens = [lens.read(i) for i in dir["f1"]]
     sections = {}
     sect_lens = []
@@ -171,7 +168,7 @@ def len_to_system(fil, item=None):
 
 def glc_read(f, session):
     cat = Catalog()
-    f = io.open(f, "r")
+    f = open(f)
     ver, num, cat.name = f.readline().split()[:3]
     cat.version = float(ver)
     cat.type, cat.source, cat.format = "material", "oslo", "glc"

--- a/rayopt/paraxial_trace.py
+++ b/rayopt/paraxial_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import itertools
 
@@ -41,7 +38,7 @@ class ParaxialTrace(Trace):
     # over optical output sine for all rays:
     # m = n0 sin u0/ (nk sin uk)
     def __init__(self, system, axis=1, update=True):
-        super(ParaxialTrace, self).__init__(system)
+        super().__init__(system)
         self.axis = axis
         if update:
             self.update()
@@ -57,7 +54,7 @@ class ParaxialTrace(Trace):
         return self.system.wavelengths[0]
 
     def allocate(self):
-        super(ParaxialTrace, self).allocate()
+        super().allocate()
         n = self.length
         if hasattr(self, "n") and self.n.shape[0] == n:
             return
@@ -82,7 +79,7 @@ class ParaxialTrace(Trace):
             u[0] = 0, n0*c
 
     def propagate(self, start=1, stop=None):
-        super(ParaxialTrace, self).propagate()
+        super().propagate()
         init = start - 1
         # FIXME not really round for gen astig...
         yu = np.vstack((self.y[init], self.y[init],

--- a/rayopt/poly_trace.py
+++ b/rayopt/poly_trace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import itertools
 from collections import namedtuple
@@ -48,7 +45,7 @@ class PolyTrace(Trace):
     simplex_accel.pyx).
     """
     def __init__(self, system, kmax=3, wavelength=0):
-        super(PolyTrace, self).__init__(system)
+        super().__init__(system)
         self.kmax = kmax
         self.l = self.system.wavelengths[wavelength]
         self.allocate()
@@ -58,7 +55,7 @@ class PolyTrace(Trace):
             self.bst = self.transform()
 
     def allocate(self):
-        super(PolyTrace, self).allocate()
+        super().allocate()
         self.Simplex = make_simplex(3, self.kmax)
         n = self.length
         self.n = np.empty(n)
@@ -86,7 +83,7 @@ class PolyTrace(Trace):
         self._state = state
 
     def propagate(self, start=1, stop=None):
-        super(PolyTrace, self).propagate()
+        super().propagate()
         state = self._state
         self.stvwof[start - 1] = (state.s, state.t, state.v, state.w,
                                   state.o, state.f)
@@ -160,7 +157,7 @@ class PolyTrace(Trace):
 
     def print_seidel(self):
         for n, v in self.seidel(*self.st()):
-            yield "{:3s}: {:12.5e}".format(n, v)
+            yield f"{n:3s}: {v:12.5e}"
 
     names = [
         # s/bs, t/bt [1:10]
@@ -187,7 +184,7 @@ class PolyTrace(Trace):
                 self.Simplex.i[i, j, k], i, j, k, nt, t)
 
     def print_params(self):
-        yield "maximum order: {:d}".format(self.Simplex.n)
+        yield f"maximum order: {self.Simplex.n:d}"
         yield "wavelength: {:g}".format(self.l/1e-9)
 
     def print_trace(self, components="stvwof", elements=None, cutoff=None,
@@ -200,14 +197,14 @@ class PolyTrace(Trace):
                 idx = slice(None)
             else:
                 idx = self.Simplex.j.sum(1) < cutoff
-            yield "{:s}".format(n.upper())
+            yield f"{n.upper():s}"
             yield "  n  i  j  k " + " ".join(
-                "{:12d}".format(i) for i in elements)
+                f"{i:12d}" for i in elements)
             for (i, j, k), ai in zip(self.Simplex.j[idx], a[idx][:, elements]):
                 i = "{:3d}{:3d}{:3d}{:3d}".format(self.Simplex.i[i, j, k],
                                                   i, j, k)
-                ai = " ".join("{:12.5e}".format(j) for j in ai)
-                yield "{:s} {:s}".format(i, ai)
+                ai = " ".join(f"{j:12.5e}" for j in ai)
+                yield f"{i:s} {ai:s}"
             yield ""
 
     def __str__(self):

--- a/rayopt/pupils.py
+++ b/rayopt/pupils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2014 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 
@@ -50,7 +47,7 @@ class Pupil(NameMixin):
             self.radius = radius
 
     def dict(self):
-        dat = super(Pupil, self).dict()
+        dat = super().dict()
         dat["distance"] = float(self.distance)
         if not self.update_distance:
             dat["update_distance"] = self.update_distance
@@ -117,17 +114,16 @@ class NaPupil(Pupil):
     na = None
 
     def __init__(self, na, **kwargs):
-        super(NaPupil, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.na = na
 
     def dict(self):
-        dat = super(NaPupil, self).dict()
+        dat = super().dict()
         dat["na"] = float(self.na)
         return dat
 
     def text(self):
-        for i in super(NaPupil, self).text():
-            yield i
+        yield from super().text()
         yield "NA: %g" % self.na
 
     @property
@@ -150,17 +146,16 @@ class SlopePupil(Pupil):
     slope = None
 
     def __init__(self, slope, **kwargs):
-        super(SlopePupil, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.slope = slope
 
     def dict(self):
-        dat = super(SlopePupil, self).dict()
+        dat = super().dict()
         dat["slope"] = float(self.slope)
         return dat
 
     def text(self):
-        for i in super(SlopePupil, self).text():
-            yield i
+        yield from super().text()
         yield "Slope: %g" % self.slope
 
     @property
@@ -179,21 +174,20 @@ class RadiusPupil(Pupil):
     radius = None
 
     def __init__(self, radius, **kwargs):
-        super(RadiusPupil, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.radius = radius
 
     def dict(self):
-        dat = super(RadiusPupil, self).dict()
+        dat = super().dict()
         dat["radius"] = float(self.radius)
         return dat
 
     def text(self):
-        for i in super(RadiusPupil, self).text():
-            yield i
+        yield from super().text()
         yield "Radius: %g" % self.radius
 
     def rescale(self, scale):
-        super(RadiusPupil, self).rescale(scale)
+        super().rescale(scale)
         self.radius *= scale
 
 
@@ -204,17 +198,16 @@ class FnoPupil(Pupil):
     fno = None
 
     def __init__(self, fno, **kwargs):
-        super(FnoPupil, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.fno = fno
 
     def dict(self):
-        dat = super(FnoPupil, self).dict()
+        dat = super().dict()
         dat["fno"] = float(self.fno)
         return dat
 
     def text(self):
-        for i in super(FnoPupil, self).text():
-            yield i
+        yield from super().text()
         yield "F-Number: %g" % self.fno
 
     @property

--- a/rayopt/raytrace.py
+++ b/rayopt/raytrace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 
@@ -25,7 +22,7 @@ from .utils import public
 
 
 @public
-class Trace(object):
+class Trace:
     def __init__(self, system):
         self.system = system
 

--- a/rayopt/rii.py
+++ b/rayopt/rii.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import yaml
 import os
@@ -66,7 +63,7 @@ def yml_read(fil, session):
                     continue
                 fil = os.path.join(path, page["path"])
                 try:
-                    data = yaml.safe_load(open(fil, "r"))
+                    data = yaml.safe_load(open(fil))
                     data["BOOK"] = book["BOOK"]
                     data["PAGE"] = page["PAGE"]
                     data["name"] = page["name"]
@@ -78,7 +75,7 @@ def yml_read(fil, session):
                         comment=page["path"], data=yaml.dump(data))
                     cat.materials.append(g)
                 except Exception as e:
-                    print("error: {}: {}".format(page, e))
+                    print(f"error: {page}: {e}")
     return top
 
 

--- a/rayopt/simplex.py
+++ b/rayopt/simplex.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 
@@ -111,7 +108,7 @@ def simplex_idx(d, m):
 
 def make_simplex(d0, n0):
     class Simplex(np.ndarray):
-        """
+        r"""
         Truncated multinomial over R^d of maximal order n.
 
         The coefficients cover the n-scaled (d+1)-simplex (cube corner in
@@ -192,5 +189,5 @@ def make_simplex(d0, n0):
             p = simplex_transform(self.i.ravel(), self.j, self, t)
             return p.view(self.__class__)
 
-    Simplex.__name__ = str("Simplex{}d{}n".format(d0, n0))
+    Simplex.__name__ = f"Simplex{d0}d{n0}n"
     return Simplex

--- a/rayopt/simplex_accel.pyx
+++ b/rayopt/simplex_accel.pyx
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -18,9 +17,6 @@
 
 #cython: boundscheck=False, wraparound=False, cdivision=True,
 #cython: embedsignature=True, initializedcheck=False
-
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import cython
 import numpy as np

--- a/rayopt/special_sums.py
+++ b/rayopt/special_sums.py
@@ -17,8 +17,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import numpy as np
 

--- a/rayopt/system.py
+++ b/rayopt/system.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import itertools
 
@@ -41,7 +38,7 @@ class System(list):
                  object=None, image=None,
                  pickups=None, validators=None, solves=None):
         elements = [Element.make(_) for _ in elements or []]
-        super(System, self).__init__(elements)
+        super().__init__(elements)
         self.description = description
         self.scale = scale
         self.wavelengths = wavelengths or [fraunhofer[i] for i in "dCF"]
@@ -295,7 +292,7 @@ class System(list):
             yield " " + line
         yield "Stop: %i" % self.stop
         yield "Elements:"
-        yield "%2s %1s %10s %10s %10s %17s %7s %7s %7s" % (
+        yield "{:>2} {:>1} {:>10} {:>10} {:>10} {:>17} {:>7} {:>7} {:>7}".format(
                 "#", "T", "Distance", "Rad Curv", "Diameter",
                 "Material", "n", "nd", "Vd")
         for i, e in enumerate(self):

--- a/rayopt/test/test_analysis.py
+++ b/rayopt/test/test_analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_cachend.py
+++ b/rayopt/test/test_cachend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_conjugates.py
+++ b/rayopt/test/test_conjugates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_elements.py
+++ b/rayopt/test/test_elements.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_poly.py
+++ b/rayopt/test/test_poly.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_raytrace.py
+++ b/rayopt/test/test_raytrace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_seidel.py
+++ b/rayopt/test/test_seidel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2015 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_utils.py
+++ b/rayopt/test/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/test/test_yaml.py
+++ b/rayopt/test/test_yaml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2014 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import unittest
 

--- a/rayopt/transformations.py
+++ b/rayopt/transformations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # transformations.py
 
 # Copyright (c) 2006-2015, Christoph Gohlke
@@ -30,7 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Homogeneous Transformation Matrices and Quaternions.
+r"""Homogeneous Transformation Matrices and Quaternions.
 
 A library for calculating 4x4 matrices for translating, rotating, reflecting,
 scaling, shearing, projecting, orthogonalizing, and superimposing arrays of
@@ -193,7 +192,6 @@ True
 
 """
 
-from __future__ import division, print_function
 
 import math
 
@@ -887,7 +885,7 @@ def orthogonalization_matrix(lengths, angles):
 
 
 def affine_matrix_from_points(v0, v1, shear=True, scale=True, usesvd=True):
-    """Return affine transform matrix to register two point sets.
+    r"""Return affine transform matrix to register two point sets.
 
     v0 and v1 are shape (ndims, \*) arrays of at least ndims non-homogeneous
     coordinates, where ndims is the dimensionality of the coordinate space.
@@ -996,7 +994,7 @@ def affine_matrix_from_points(v0, v1, shear=True, scale=True, usesvd=True):
 
 
 def superimposition_matrix(v0, v1, scale=False, usesvd=True):
-    """Return matrix to transform given 3D point set into second point set.
+    r"""Return matrix to transform given 3D point set into second point set.
 
     v0 and v1 are shape (3, \*) or (4, \*) arrays of at least 3 points.
 
@@ -1503,7 +1501,7 @@ def random_rotation_matrix(rand=None):
     return quaternion_matrix(random_quaternion(rand))
 
 
-class Arcball(object):
+class Arcball:
     """Virtual Trackball Control.
 
     >>> ball = Arcball()
@@ -1673,7 +1671,7 @@ _AXES2TUPLE = {
     'rzxy': (1, 1, 0, 1), 'ryxy': (1, 1, 1, 1), 'ryxz': (2, 0, 0, 1),
     'rzxz': (2, 0, 1, 1), 'rxyz': (2, 1, 0, 1), 'rzyz': (2, 1, 1, 1)}
 
-_TUPLE2AXES = dict((v, k) for k, v in _AXES2TUPLE.items())
+_TUPLE2AXES = {v: k for k, v in _AXES2TUPLE.items()}
 
 
 def vector_norm(data, axis=None, out=None):

--- a/rayopt/utils.py
+++ b/rayopt/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2013 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 import sys
 

--- a/rayopt/zemax.py
+++ b/rayopt/zemax.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 #   rayopt - raytracing for optical imaging systems
 #   Copyright (C) 2012 Robert Jordens <robert@joerdens.org>
@@ -16,8 +15,6 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (absolute_import, print_function,
-                        unicode_literals, division)
 
 from struct import Struct
 import os
@@ -45,7 +42,7 @@ def zmf_read(file, session):
     cat.load(file)
     cat.name = os.path.splitext(os.path.basename(file))[0]
     cat.type, cat.source, cat.format = "lens", "zemax", "zmx"
-    f = io.open(file, "rb")
+    f = open(file, "rb")
     head = Struct("<I")
     lens = Struct("<100sIIIIIIIdd")
     shapes = "?EBPM"
@@ -73,7 +70,7 @@ def zmf_read(file, session):
         assert len(description) == li[7]
         description = zmf_obfuscate(description, l.efl, l.enp)
         description = description.decode("latin1")
-        assert description.startswith("VERS {:06d}\n".format(l.version))
+        assert description.startswith(f"VERS {l.version:06d}\n")
         l.data = description
         cat.lenses.append(l)
     return cat
@@ -84,7 +81,7 @@ def zmf_obfuscate(data, a, b):
     iv = np.cos(655*(np.pi/180)*iv) + iv
     p = np.arange(len(data))
     k = 13.2*(iv + np.sin(17*(p + 3)))*(p + 1)
-    k = (int(("{:.8e}".format(_))[4:7]) for _ in k)
+    k = (int((f"{_:.8e}")[4:7]) for _ in k)
     data = np.fromstring(data, np.uint8)
     data ^= np.fromiter(k, np.uint8, len(data))
     return data.tostring()
@@ -195,9 +192,9 @@ def agf_read(fil, session):
     session.add(cat)
     raw = open(fil, "rb").read(32)
     if raw.startswith(codecs.BOM_UTF16):
-        dat = io.open(fil, encoding="utf-16")
+        dat = open(fil, encoding="utf-16")
     else:
-        dat = io.open(fil, encoding="latin1")
+        dat = open(fil, encoding="latin1")
     for line in dat:
         if not line.strip():
             continue

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         Intended Audience :: Science/Research
         License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
         Operating System :: OS Independent
-        Programming Language :: Python :: 2
         Programming Language :: Python :: 3
         Topic :: Scientific/Engineering :: Physics
     """.splitlines() if f.strip()],

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,11 @@ setup(
     extras_require={},
     packages=find_packages(),
     test_suite="rayopt.test",
-    ext_modules=cythonize([
-        Extension("rayopt._transformations",
-                  sources=["rayopt/_transformations.c"]),
-        Extension("rayopt.simplex_accel",
-                  sources=["rayopt/simplex_accel.pyx"]),
-    ]),
+    ext_modules=cythonize([Extension("rayopt._transformations",
+                                     sources=["rayopt/_transformations.c"]),
+                           Extension("rayopt.simplex_accel",
+                                     sources=["rayopt/simplex_accel.pyx"])],
+                          language_level='3'),
     include_dirs=[np.get_include()],
     entry_points={},
     package_data={


### PR DESCRIPTION
Since Python 2.7 is end of life, bump support to Python 3
only. The oldest version with active full support is python
3.7.  This also gives us support for glorious f-strings.